### PR TITLE
Fix py-sema link in software packages page

### DIFF
--- a/software-packages.md
+++ b/software-packages.md
@@ -35,7 +35,7 @@ items:
 
   - title: "py-sema"
     description: "Python package involving semantic manipulation of RDF data."
-    clickthrough_url: https://github.com/vliz-be-opsci/py-sdn-cdi-client
+    clickthrough_url: https://github.com/vliz-be-opsci/py-sema
     image: "/assets/media/img/socials/github-mark.svg"
     tags:
       - k-gap


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the clickthrough URL for the "py-sema" package to ensure users access the correct resource.
  
- **Documentation**
	- Updated the software packages documentation to reflect the current status of packages, including the removal of inactive entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->